### PR TITLE
Fix Tab Styling Issues

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,6 +31,7 @@
 	margin: 0 5px 0 0; 
 	padding: 0;
 	text-align: center;
+	overflow: auto;
 }
 	
 .ui-tabs ul.ui-tabs-nav li a {

--- a/style.css
+++ b/style.css
@@ -27,7 +27,7 @@
 }
 	
 .ui-tabs ul.ui-tabs-nav li {
-	display: inline;
+	display: inline-block;
 	margin: 0 5px 0 0; 
 	padding: 0;
 	text-align: center;


### PR DESCRIPTION
With the default Genesis theme enabled, I had trouble with the tab styling. By default, I saw this:

![screen shot 2014-07-05 at 10 53 05 am](https://cloud.githubusercontent.com/assets/527488/3488608/11e7c1dc-04f6-11e4-84cd-60f14a60ada7.png)

`display: inline-block` fixes the tabs wrapping oddly onto the next line:

![screen shot 2014-07-05 at 11 14 33 am](https://cloud.githubusercontent.com/assets/527488/3488609/23865764-04f6-11e4-9a4d-e63340f53606.png)

And `overflow: auto` makes the tabs readable again. I didn't want to make any design decisions, so I just went with the most reliable fix to make the tabs equally spaced. They look like so after the change:

![screen shot 2014-07-06 at 6 10 10 am](https://cloud.githubusercontent.com/assets/527488/3488616/52a851be-04f6-11e4-83b7-be5162d7f129.png)
